### PR TITLE
New version v1.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,18 +2,18 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "amq-protocol"
-version = "6.0.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede228647914ef8ac4ef4cfddbe3be4c23afea8d8c7f95451a2f53efe6ce8f2f"
+checksum = "3c222de30b345b19470d9091414c5bda68cd845c44e8dde2f874373e0b247a54"
 dependencies = [
  "amq-protocol-tcp",
  "amq-protocol-types",
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "6.0.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4860b3d63ffb63b3ed440b78ccd549b009e0f72d995b9e9aec51e8e1af01e694"
+checksum = "bee3c947a2c5b40b6e506453eeff96998bb2caa2ea616ed028ba1bafbc2b16ce"
 dependencies = [
  "amq-protocol-uri",
  "tcp-stream",
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-types"
-version = "6.0.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ebe159bbe5fff48b5702d639ba9b0a7b1b2f24c4404fe38db0cbcafd057c01"
+checksum = "d198cde4bde0eadf1a946e4f0d113ff471bf8abe4ef728181d7320461da8a3e4"
 dependencies = [
  "cookie-factory",
  "nom",
@@ -47,12 +47,12 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "6.0.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82403806f8fef7e9d8dc6dcb41839a47a8eab9419f9dca52ef6b19904e0047e"
+checksum = "9f843ece1f9a66cebbccf4162b5505e96e93598d3b2678ac56ad19d60642bd45"
 dependencies = [
  "percent-encoding 2.1.0",
- "url 2.2.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -83,16 +83,16 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "once_cell",
- "vec-arena",
+ "slab",
 ]
 
 [[package]]
@@ -113,29 +113,29 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+checksum = "4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "libc",
  "log",
- "nb-connect",
  "once_cell",
  "parking",
  "polling",
- "vec-arena",
+ "slab",
+ "socket2",
  "waker-fn",
  "winapi",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
 dependencies = [
  "event-listener",
 ]
@@ -269,15 +269,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -347,22 +341,22 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -374,9 +368,9 @@ checksum = "85a8ec66fa7486297a4e828f5cabe4e34a4b4934058010753767421bd3717ad7"
 
 [[package]]
 name = "ctor"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote",
  "syn",
@@ -434,9 +428,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "fastrand"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
 ]
@@ -474,9 +468,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -489,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -499,15 +493,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -516,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
@@ -537,10 +531,11 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -549,22 +544,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -581,11 +577,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -631,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -646,7 +642,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -657,9 +653,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -675,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "lapin"
-version = "1.6.8"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7078dde0a1102a8d152c89ed1f3df07c410d1142c9a376add5dd5685b92d0b0d"
+checksum = "5b9d21a790e85496a97d9b82821aa39c59579433e9ad29d7c1ab54d9807ebfcc"
 dependencies = [
  "amq-protocol",
  "async-task",
@@ -698,28 +694,28 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexical-core"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ryu",
  "static_assertions",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -730,7 +726,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "value-bag",
 ]
 
@@ -742,15 +738,15 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
@@ -761,11 +757,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi",
 ]
 
@@ -795,16 +790,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nb-connect"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
-dependencies = [
- "libc",
- "socket2",
 ]
 
 [[package]]
@@ -866,29 +851,29 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
  "autocfg",
  "cc",
@@ -920,7 +905,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
@@ -982,11 +967,11 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polling"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "log",
  "wepoll-sys",
@@ -1013,9 +998,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -1042,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "rabbitmq-consumer"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "async-std",
  "base64",
@@ -1109,30 +1094,29 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1176,9 +1160,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1189,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1199,18 +1183,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1239,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
@@ -1251,11 +1235,10 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
  "winapi",
 ]
@@ -1274,9 +1257,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.63"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1291,11 +1274,11 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tcp-stream"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c180af0da0f0a75ca080465175892fcdaa750076f125cb953127721e676413"
+checksum = "9a29af643fc448ecb2d9b8a74aa2c60c72c36cb447bcf490b866797b58f00f13"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "mio",
  "native-tls",
  "pem",
@@ -1307,7 +1290,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand",
  "redox_syscall",
@@ -1334,15 +1317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1369,9 +1343,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1389,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c535f53c0cfa1acace62995a8994fc9cc1f12d202420da96ff306ee24d576469"
+checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1420,26 +1394,26 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -1461,9 +1435,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"
@@ -1478,36 +1452,31 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.2",
+ "idna 0.2.3",
  "matches",
  "percent-encoding 2.1.0",
 ]
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
+checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
 dependencies = [
  "ctor",
+ "version_check",
 ]
 
 [[package]]
 name = "vcpkg"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
-
-[[package]]
-name = "vec-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"
@@ -1517,9 +1486,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "waker-fn"
@@ -1535,19 +1504,19 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1560,11 +1529,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.21"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1572,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1582,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1595,15 +1564,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-    name = "rabbitmq-consumer"
-    version = "1.2.2"
-    authors = ["Dario Cancelliere <dario.cancelliere@facile.it>"]
-    edition = "2018"
+name = "rabbitmq-consumer"
+version = "1.2.3"
+authors = ["Dario Cancelliere <emulator000@gmail.com>"]
+edition = "2018"
 
 [lib]
-    name = "rabbitmq_consumer_lib"
-    path = "src/lib.rs"
+name = "rabbitmq_consumer_lib"
+path = "src/lib.rs"
 
 [profile.release]
-    lto = true
+lto = true
 
 [dependencies]
-    async-std = "^1.9"
-    tokio = { version = "^1.3", features = ["full"] }
-    tokio-stream = "^0.1"
-    futures = "^0.3"
-    lapin = "^1.6"
-    toml = "^0.5"
-    serde = "^1.0"
-    serde_derive = "^1.0"
-    diesel = { version = "^1.4", features = ["mysql", "chrono", "r2d2"] }
-    chrono = { version = "^0.4", features = ["serde"] }
-    log = "^0.4"
-    env_logger = "^0.8"
-    base64 = "^0.13"
-    clap = "^2.33"
-    crystalsoft-utils = "^0.1"
+async-std = "^1.9"
+tokio = { version = "^1.6", features = ["full"] }
+tokio-stream = "^0.1"
+futures = "^0.3"
+lapin = "^1.7"
+toml = "^0.5"
+serde = "^1.0"
+serde_derive = "^1.0"
+diesel = { version = "^1.4", features = ["mysql", "chrono", "r2d2"] }
+chrono = { version = "^0.4", features = ["serde"] }
+log = "^0.4"
+env_logger = "^0.8"
+base64 = "^0.13"
+clap = "^2.33"
+crystalsoft-utils = "^0.1"

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 
 A configurable RabbitMQ consumer made in Rust, useful for a stable and reliable CLI commands processor.
 
-## 1.2.0 warning
+## Version 1.2.0 and 1.2.3 warning
 
-In order to use this version correctly and only if you use the MySQL configuration for queues, you have to update your `queues` table schema adding a new `nack_code` integer field:
+In order to use this version correctly and only if you use the MySQL configuration for queues, you have to update your `queues` table schema adding a new `nack_code` and `prefetch_count` integer columns:
 
 ```sql
 ALTER TABLE queues ADD nack_code INT(11) DEFAULT 2 NULL;
+ALTER TABLE queues ADD prefetch_count INT(11) DEFAULT 1 NULL;
 ```
 
 ## Installation

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 use std::env;
 
 fn main() {
-    if "release" == env::var("PROFILE").unwrap_or("".into()) {
+    if "release" == env::var("PROFILE").unwrap_or_else(|_| "".into()) {
         println!(r"cargo:rustc-link-lib=static=mysqlclient");
-        println!(r"cargo:rustc-link-lib=static-nobundle=stdc++");
+        println!(r"cargo:rustc-link-lib=static:-bundle=stdc++");
         println!(r"cargo:rustc-link-lib=static=z");
         println!(r"cargo:rustc-link-lib=static=ssl");
         println!(r"cargo:rustc-link-lib=static=crypto");

--- a/src/client/consumer/channel.rs
+++ b/src/client/consumer/channel.rs
@@ -20,7 +20,7 @@ impl Channel {
         let channel = connection.create_channel().await?;
         channel
             .basic_qos(
-                1,
+                queue.prefetch_count.unwrap_or(1) as u16,
                 BasicQosOptions {
                     ..Default::default()
                 },

--- a/src/client/consumer/channel.rs
+++ b/src/client/consumer/channel.rs
@@ -1,14 +1,13 @@
 use async_std::sync::Arc;
 
+use log::info;
+
 use lapin::options::{BasicQosOptions, QueueDeclareOptions};
 use lapin::{types::FieldTable, Channel as LapinChannel, Connection, Error as LapinError, Queue};
 
 use crate::config::queue::config::QueueConfig;
 
-#[derive(Debug)]
-pub enum ChannelError {
-    LapinError(LapinError),
-}
+type ChannelResult = Result<(LapinChannel, Queue), LapinError>;
 
 pub struct Channel {}
 
@@ -17,11 +16,8 @@ impl Channel {
         connection: Arc<Connection>,
         queue: QueueConfig,
         prefix: S,
-    ) -> Result<(LapinChannel, Queue), ChannelError> {
-        let channel = connection
-            .create_channel()
-            .await
-            .map_err(ChannelError::LapinError)?;
+    ) -> ChannelResult {
+        let channel = connection.create_channel().await?;
         channel
             .basic_qos(
                 1,
@@ -29,8 +25,7 @@ impl Channel {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(ChannelError::LapinError)?;
+            .await?;
 
         info!(
             "[{}] Created channel with id: {}",
@@ -48,8 +43,7 @@ impl Channel {
                 },
                 FieldTable::default(),
             )
-            .await
-            .map_err(ChannelError::LapinError)?;
+            .await?;
 
         Ok((channel, queue))
     }

--- a/src/client/consumer/connection.rs
+++ b/src/client/consumer/connection.rs
@@ -1,5 +1,7 @@
 use async_std::sync::Arc;
 
+use log::info;
+
 use lapin::{
     uri::AMQPAuthority, uri::AMQPUri, uri::AMQPUserInfo, Connection as LapinConnection,
     ConnectionProperties, Error,
@@ -13,9 +15,11 @@ pub enum ConnectionError {
     LapinError(Error),
 }
 
+type ConnectionResult = Result<Arc<LapinConnection>, ConnectionError>;
+
 pub struct Connection {
     config: RabbitConfig,
-    lapin: Result<Arc<LapinConnection>, ConnectionError>,
+    lapin: ConnectionResult,
 }
 
 impl Connection {
@@ -26,7 +30,7 @@ impl Connection {
         }
     }
 
-    pub async fn get_connection(&mut self) -> Result<Arc<LapinConnection>, ConnectionError> {
+    pub async fn get_connection(&mut self) -> ConnectionResult {
         if let Ok(ref lapin) = self.lapin {
             if lapin.status().errored() {
                 self.lapin = Err(ConnectionError::NotConnected);

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -4,6 +4,8 @@ mod message;
 
 use async_std::sync::{Arc, RwLock};
 
+use log::{error, info};
+
 use tokio::signal::unix::{signal, SignalKind};
 use tokio_stream::StreamExt;
 
@@ -13,7 +15,7 @@ use futures::future::FutureExt;
 use lapin::options::{BasicCancelOptions, BasicConsumeOptions, BasicRecoverOptions};
 use lapin::{types::FieldTable, Channel as LapinChannel, Error as LapinError, Queue as LapinQueue};
 
-use crate::client::consumer::channel::{Channel, ChannelError};
+use crate::client::consumer::channel::Channel;
 use crate::client::consumer::connection::{Connection, ConnectionError};
 use crate::client::consumer::message::{Message, MessageError};
 use crate::client::executor::events::{Events, EventsHandler};
@@ -28,7 +30,7 @@ const CONSUMER_WAIT: u64 = 60000;
 const DEFAULT_WAIT_PART: u64 = 1000;
 
 #[derive(Debug, PartialEq)]
-pub enum ConsumerResult {
+pub enum ConsumerStatus {
     ConsumerChanged,
     CountChanged,
     GenericOk,
@@ -40,9 +42,10 @@ pub enum ConsumerError {
     LapinError(LapinError),
     IoError(std::io::Error),
     ConnectionError(ConnectionError),
-    ChannelError(ChannelError),
     MessageError(MessageError),
 }
+
+type ConsumerResult<T> = Result<T, ConsumerError>;
 
 pub struct Consumer {
     queue: Arc<RwLock<Queue>>,
@@ -71,7 +74,7 @@ impl Consumer {
         }
     }
 
-    pub async fn run(&mut self) -> Result<ConsumerResult, ConsumerError> {
+    pub async fn run(&mut self) -> ConsumerResult<ConsumerStatus> {
         match self.connection.get_connection().await {
             Ok(connection) => {
                 for hook in &self.hooks {
@@ -81,12 +84,12 @@ impl Consumer {
                 }
 
                 let mut sigint = signal(SignalKind::interrupt()).map_err(ConsumerError::IoError)?;
-                let sigint = sigint.recv().map(|_| Ok(ConsumerResult::Killed));
+                let sigint = sigint.recv().map(|_| Ok(ConsumerStatus::Killed));
                 let mut sigquit = signal(SignalKind::quit()).map_err(ConsumerError::IoError)?;
-                let sigquit = sigquit.recv().map(|_| Ok(ConsumerResult::Killed));
+                let sigquit = sigquit.recv().map(|_| Ok(ConsumerStatus::Killed));
                 let mut sigterm =
                     signal(SignalKind::terminate()).map_err(ConsumerError::IoError)?;
-                let sigterm = sigterm.recv().map(|_| Ok(ConsumerResult::Killed));
+                let sigterm = sigterm.recv().map(|_| Ok(ConsumerStatus::Killed));
 
                 let mut futures = Vec::new();
                 futures.push(sigint.boxed());
@@ -115,7 +118,7 @@ impl Consumer {
 
                                     self.consume(index, queue.clone(), c, q).boxed()
                                 }
-                                Err(e) => async { Err(ConsumerError::ChannelError(e)) }.boxed(),
+                                Err(e) => async { Err(ConsumerError::LapinError(e)) }.boxed(),
                             },
                         );
                     }
@@ -135,7 +138,7 @@ impl Consumer {
         queue_config: QueueConfig,
         channel: LapinChannel,
         queue: LapinQueue,
-    ) -> Result<ConsumerResult, ConsumerError> {
+    ) -> ConsumerResult<ConsumerStatus> {
         let consumer_name = format!("{}_consumer_{}", queue_config.consumer_name, index);
 
         if !self.queue.write().await.is_enabled(queue_config.id) {
@@ -192,7 +195,7 @@ impl Consumer {
                                         .await
                                         .is_err()
                                     {
-                                        info!(
+                                        error!(
                                             "[{}] Error canceling the consumer #{}, returning...",
                                             queue_config.queue_name, index
                                         );
@@ -206,13 +209,13 @@ impl Consumer {
                                     .await
                                     .is_err()
                                 {
-                                    info!(
+                                    error!(
                                             "[{}] Error recovering message for consumer #{}, message is not ackable...",
                                             queue_config.queue_name,
                                             index
                                         );
 
-                                    return Ok(ConsumerResult::GenericOk);
+                                    return Ok(ConsumerStatus::GenericOk);
                                 }
 
                                 info!(
@@ -221,27 +224,27 @@ impl Consumer {
                                         index
                                     );
 
-                                return Ok(ConsumerResult::ConsumerChanged);
+                                return Ok(ConsumerStatus::ConsumerChanged);
                             } else if is_changed {
                                 info!(
                                     "[{}] Consumers count changed, messages recovered...",
                                     queue_config.queue_name
                                 );
 
-                                return Ok(ConsumerResult::CountChanged);
+                                return Ok(ConsumerStatus::CountChanged);
                             }
                         }
                         Err(e) => {
-                            info!("[{}] Error getting messages.", queue_config.queue_name);
+                            error!("[{}] Error getting messages.", queue_config.queue_name);
 
                             return Err(ConsumerError::LapinError(e));
                         }
                     }
                 }
 
-                info!("Messages has been processed.");
+                info!("Messages have been processed.");
 
-                Ok(ConsumerResult::GenericOk)
+                Ok(ConsumerStatus::GenericOk)
             }
             Err(e) => Err(ConsumerError::LapinError(e)),
         }
@@ -251,6 +254,7 @@ impl Consumer {
         while async {
             if !self.queue.write().await.is_enabled(queue_config.id) {
                 utils::wait(CONSUMER_WAIT).await;
+
                 Some(())
             } else {
                 None

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -91,10 +91,7 @@ impl Consumer {
                     signal(SignalKind::terminate()).map_err(ConsumerError::IoError)?;
                 let sigterm = sigterm.recv().map(|_| Ok(ConsumerStatus::Killed));
 
-                let mut futures = Vec::new();
-                futures.push(sigint.boxed());
-                futures.push(sigquit.boxed());
-                futures.push(sigterm.boxed());
+                let mut futures = vec![sigint.boxed(), sigquit.boxed(), sigterm.boxed()];
 
                 info!("Managing queues...");
 

--- a/src/config/database/mod.rs
+++ b/src/config/database/mod.rs
@@ -1,5 +1,7 @@
 mod schema;
 
+use log::info;
+
 use diesel::mysql::MysqlConnection;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool};

--- a/src/config/database/schema.rs
+++ b/src/config/database/schema.rs
@@ -1,6 +1,7 @@
 table! {
     queues {
         id -> Integer,
+        prefetch_count -> Nullable<Integer>,
         queue_name -> Varchar,
         consumer_name -> Varchar,
         command -> Varchar,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,8 @@ use std::env;
 use std::fs::File;
 use std::path::Path;
 
+use log::info;
+
 use serde::Deserialize;
 
 use crate::config::queue::config::QueueConfig;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -63,7 +63,7 @@ impl Config {
         match crystalsoft_utils::read_file_string(&config) {
             Err(why) => panic!("Couldn't read \"{}\": {:#?}", config, why),
             Ok(mut configuration) => {
-                info!("\"{}\" loaded correctly.", config);
+                info!("File \"{}\" loaded correctly.", config);
 
                 let variables: HashMap<_, _> = env::vars().collect();
                 for (key, value) in variables {

--- a/src/config/queue/config.rs
+++ b/src/config/queue/config.rs
@@ -10,6 +10,8 @@ use crate::utils::{
 pub struct QueueConfig {
     #[serde(deserialize_with = "i32_or_string")]
     pub id: i32,
+    #[serde(deserialize_with = "option_i32_or_string", default)]
+    pub prefetch_count: Option<i32>,
     pub queue_name: String,
     pub consumer_name: String,
     pub command: String,

--- a/src/config/queue/config.rs
+++ b/src/config/queue/config.rs
@@ -1,3 +1,5 @@
+use serde::Deserialize;
+
 use chrono::{self, NaiveTime};
 
 use crate::utils::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
 #![feature(static_nobundle)]
-#[macro_use]
-extern crate serde_derive;
+
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate log;
 
 pub mod client;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::io::Write;
 
 use clap::{App, Arg};
@@ -9,10 +8,11 @@ use env_logger::Env;
 
 use chrono::Local;
 
-use rabbitmq_consumer_lib::client::{Client, ClientResult};
+use rabbitmq_consumer_lib::client::consumer::ConsumerError;
+use rabbitmq_consumer_lib::client::Client;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), ConsumerError> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format(|buf, record| {
             writeln!(
@@ -61,14 +61,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("{}", description);
     info!("");
 
-    match Client::new(
+    Client::new(
         matches.value_of("env").unwrap(),
         matches.value_of("path").unwrap(),
     )
     .run()
     .await
-    {
-        ClientResult::Ok => Ok(()),
-        ClientResult::ConsumerError(_) => Ok(()),
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), ConsumerError> {
         .format(|buf, record| {
             writeln!(
                 buf,
-                "{} [{}] - {}",
+                "{} [{}] {}",
                 Local::now().format("%Y-%m-%dT%H:%M:%S"),
                 record.level(),
                 record.args()

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -6,7 +6,7 @@ use lapin::Connection as LapinConnection;
 
 use rabbitmq_consumer_lib::client::consumer::channel::Channel;
 use rabbitmq_consumer_lib::client::consumer::connection::{Connection, ConnectionError};
-use rabbitmq_consumer_lib::client::consumer::{Consumer, ConsumerResult};
+use rabbitmq_consumer_lib::client::consumer::{Consumer, ConsumerStatus};
 use rabbitmq_consumer_lib::config::file::File;
 use rabbitmq_consumer_lib::config::queue::config::QueueConfig;
 use rabbitmq_consumer_lib::config::queue::Queue;
@@ -16,6 +16,7 @@ fn get_queues() -> Vec<QueueConfig> {
     vec![
         QueueConfig {
             id: 1,
+            prefetch_count: None,
             queue_name: "example".into(),
             consumer_name: "example".into(),
             command: "echo 1".into(),
@@ -31,6 +32,7 @@ fn get_queues() -> Vec<QueueConfig> {
         },
         QueueConfig {
             id: 2,
+            prefetch_count: Some(1),
             queue_name: "example2".into(),
             consumer_name: "example".into(),
             command: "echo 1".into(),
@@ -46,6 +48,7 @@ fn get_queues() -> Vec<QueueConfig> {
         },
         QueueConfig {
             id: 3,
+            prefetch_count: None,
             queue_name: "example3".into(),
             consumer_name: "example".into(),
             command: "echo 1".into(),
@@ -170,7 +173,12 @@ async fn consumer_changed() {
     let consumer = Consumer::new(config);
 
     let result = consumer.consume(0, queue_config, channel, queue).await;
-
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), ConsumerResult::CountChanged);
+    match result {
+        Ok(result) => {
+            assert_eq!(result, ConsumerStatus::CountChanged);
+        }
+        Err(e) => {
+            assert!(false, "{:#?}", e);
+        }
+    }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -100,6 +100,7 @@ async fn retry_type() {
     let queues = vec![
         QueueConfig {
             id: 1,
+            prefetch_count: None,
             queue_name: "example".into(),
             consumer_name: "example".into(),
             command: "echo 1".into(),
@@ -115,6 +116,7 @@ async fn retry_type() {
         },
         QueueConfig {
             id: 2,
+            prefetch_count: Some(2),
             queue_name: "example2".into(),
             consumer_name: "example".into(),
             command: "echo 1".into(),
@@ -130,6 +132,7 @@ async fn retry_type() {
         },
         QueueConfig {
             id: 3,
+            prefetch_count: Some(10),
             queue_name: "example3".into(),
             consumer_name: "example".into(),
             command: "echo 1".into(),


### PR DESCRIPTION
In this version was introduced the new `prefetch_count` option for consumers in a queue.
- [x] Added new `prefetch_count` option for queues in order to manual specify the number of message prefetched by a consumer (issue #7)
- [x] Refactorized all Result(s) structures and other little refactors
- [x] Bugfix for logging messages and errors within the correct printing order
- [x] Updated crates